### PR TITLE
chore(DotNet) Retry building demo

### DIFF
--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -14,8 +14,13 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '15.1'
-    - name: Build demo
-      run: |
-        cd dotnet-maui
-        sudo dotnet workload restore
-        dotnet build SimpleDemo.csproj
+    # Retry in case plugin is not yet available on nuget
+    - uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 30
+        max_attempts: 2
+        retry_wait_seconds: 300
+        command: |
+          cd dotnet-maui
+          sudo dotnet workload restore
+          dotnet build SimpleDemo.csproj


### PR DESCRIPTION
Often, it takes a couple minutes for the plugin to be available on nuget after we publish it, and it makes the build job fail. Here we retry once if the build fails with a 5 minute pause between the 2 attempts.