### PR TITLE
[.Net] Upgrade MacOS and Xcode version

### DIFF
--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.1'
+        xcode-version: '16.4'
     # Retry in case plugin is not yet available on nuget
     - uses: nick-fields/retry@v3
       with:


### PR DESCRIPTION
.Net 9 only supports Xcode 16.4 and above.