### PR TITLE
[CI] Upgrade macOS machines to 26

### DIFF
--- a/.github/workflows/cordova.yml
+++ b/.github/workflows/cordova.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         working-directory: cordova-plugin-genius-scan-demo

--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.4'
+        xcode-version: '26.0.1'
     # Retry in case plugin is not yet available on nuget
     - uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-custom-demo:
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: ios/GSSDKCustomDemo
@@ -18,7 +18,7 @@ jobs:
            ONLY_ACTIVE_ARCH=YES \
            CODE_SIGNING_ALLOWED="NO"
   build-simple-demo:
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: ios/GSSDKSimpleDemo

--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -24,7 +24,7 @@ jobs:
     - run: npm install
     - run: cd android && ./gradlew assembleRelease
   ios:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Except for Cordova and Flutter which are not yet compatible. And Xcode to 26 for .Net jobs.