### PR TITLE
[Cordova] Add missing plugin file to build demo

### DIFF
--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -22,18 +22,7 @@ jobs:
           sudo dotnet workload restore
           dotnet build SimpleDemo.csproj -f net9.0-android
           dotnet build SimpleDemo.csproj -f net10.0-android
-  build-ios-dotnet9:
-    runs-on: macos-26
-    steps:
-    - uses: actions/checkout@v4
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '26.0.1'
-    - run: |
-        cd dotnet-maui
-        sudo dotnet workload restore
-        dotnet build SimpleDemo.csproj -f net9.0-ios
-  build-ios-dotnet10:
+  build-ios:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
@@ -43,4 +32,5 @@ jobs:
     - run: |
         cd dotnet-maui
         sudo dotnet workload restore
+        dotnet build SimpleDemo.csproj -f net9.0-ios
         dotnet build SimpleDemo.csproj -f net10.0-ios

--- a/cordova-plugin-genius-scan-demo/.gitignore
+++ b/cordova-plugin-genius-scan-demo/.gitignore
@@ -1,5 +1,6 @@
 platforms
 node_modules
 plugins
-package.json
 package-lock.json
+
+/package.json

--- a/cordova-plugin-genius-scan-demo/cordova-plugin-demo-preview/package.json
+++ b/cordova-plugin-genius-scan-demo/cordova-plugin-demo-preview/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cordova-plugin-demo-preview",
+  "version": "1.0.0",
+  "description": "Local file preview plugin used by the Cordova demo app.",
+  "cordova": {
+    "id": "cordova-plugin-demo-preview",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  }
+}


### PR DESCRIPTION
Only ignore the base package.json since it's generated when running `cordova prepare` but not other package.json files.